### PR TITLE
Remove touch on settings.php file

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,11 +12,6 @@
   with_dict: drupal_settings_sites
   tags: ['drupal']
 
-- name: "Make sure the settings.php files are writable"
-  file: path={{ drupal_settings_basedir }}/{{ item.key }}/settings.php state=touch mode=0664
-  with_dict: drupal_settings_sites
-  tags: ['drupal']
-
 - name: "Create settings.php files"
   template: src=settings.j2 dest={{ drupal_settings_basedir }}/{{ item.key }}/settings.php mode=0444
   with_dict: drupal_settings_sites


### PR DESCRIPTION
This touch appears to serve no purpose and breaks when using virtualbox with NFS on OS X.
